### PR TITLE
fix import source of `Array` from `_ctypes` to `ctypes`

### DIFF
--- a/comtypes/automation.py
+++ b/comtypes/automation.py
@@ -553,7 +553,7 @@ v._.VT_I4 = 0x80020004
 del v
 
 _carg_obj = type(byref(c_int()))
-from _ctypes import Array as _CArrayType
+from ctypes import Array as _CArrayType
 
 @comtypes.patcher.Patch(POINTER(VARIANT))
 class _(object):


### PR DESCRIPTION
`Array` is defined in `_ctypes` but imported to `ctypes` and can be referenced from the public module.

`- This is related to https://github.com/enthought/comtypes/issues/327#issuecomment-1225669745`