### PR TITLE
Fix cross imports part2

### DIFF
--- a/comtypes/client/_generate.py
+++ b/comtypes/client/_generate.py
@@ -265,6 +265,8 @@ def generate_module(tlib, ofi, pathname):
                     )
 
     gen.generate_code(list(items.values()), filename=pathname)
+    for ext_tlib in gen.externals:
+        GetModule(ext_tlib)
 
 ################################################################
 

--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -13,7 +13,6 @@ import textwrap
 
 from comtypes.tools import tlbparser, typedesc
 import comtypes
-import comtypes.client
 import comtypes.typeinfo
 
 version = comtypes.__version__
@@ -192,6 +191,7 @@ class Generator(object):
 
         self.done = set() # type descriptions that have been generated
         self.names = set() # names that have been generated
+        self.externals = []  # typelibs imported to generated module
         self.last_item_class = False
 
     def generate(self, item):
@@ -701,7 +701,7 @@ class Generator(object):
     def External(self, ext):
         modname = name_wrapper_module(ext.tlib)
         if modname not in self.imports:
-            comtypes.client.GetModule(ext.tlib)
+            self.externals.append(ext.tlib)
             self.imports.add(modname)
 
     def Constant(self, tp):


### PR DESCRIPTION
see #329 and https://github.com/enthought/comtypes/issues/329#issuecomment-1191557095

I defined the `externals`(`: list[typeinfo.ITypeLib]`) attribute to `tools.codegenerator.Generator`.
We no longer call `GetModule` in `tools.codegenerator`.
Now we generate dependency modules with `client._generate`.
