### PR TITLE
remove `CodeGenerator.type_name`  calls no longer needed

### DIFF
--- a/comtypes/tools/codegenerator.py
+++ b/comtypes/tools/codegenerator.py
@@ -523,11 +523,6 @@ class CodeGenerator(object):
             if body.struct.bases:
                 assert len(body.struct.bases) == 1
                 self.generate(body.struct.bases[0].get_body())
-            # field definition normally span several lines.
-            # Before we generate them, we need to 'import' everything they need.
-            # So, call type_name for each field once,
-            for f in fields:
-                self.type_name(f.typ)
 
             if not self.last_item_class:
                 print(file=self.stream)
@@ -571,13 +566,6 @@ class CodeGenerator(object):
 
         if methods:
             self.imports.add("comtypes", "COMMETHOD")
-            # method definitions normally span several lines.
-            # Before we generate them, we need to 'import' everything they need.
-            # So, call type_name for each field once,
-            for m in methods:
-                self.type_name(m.returns)
-                for a in m.iterArgTypes():
-                    self.type_name(a)
 
             if not self.last_item_class:
                 print(file=self.stream)


### PR DESCRIPTION
In the past, `CodeGenerator.type_name` is not only returning a name string, but also had the side-effect that is generating code to import the required symbols from other modules.

In order to use the side-effect, there were the calls `type_name` even though the return values were not used.

However, that side effect has already been removed, I also removed the calls that are no longer needed.

Also, `type_name` is not a proper method name, as was confused in 352.

Because of the behavior of converting the passed argument and the it is not used externally, I renamed it `_to_type_name`.