### PR TITLE
fix `test_getactiveobj`

### DIFF
--- a/comtypes/test/test_getactiveobj.py
+++ b/comtypes/test/test_getactiveobj.py
@@ -1,25 +1,31 @@
+import time
 import unittest
 
 import comtypes
 import comtypes.client
 import comtypes.test
 
-comtypes.test.requires("ui")
+try:
+    comtypes.client.GetModule(('{00020905-0000-0000-C000-000000000046}',))  # Word libUUID
+    IMPORT_FAILED = False
+except (ImportError, OSError):
+    IMPORT_FAILED = True
 
 
-def setUpModule():
-    raise unittest.SkipTest("External test dependencies like this seem bad.  Find a different "
-                            "built-in win32 API to use.")
+################################################################
+#
+# TODO:
+#
+# It seems bad that only external test like this
+# can verify the behavior of `comtypes` implementation.
+# Find a different built-in win32 API to use.
+#
+################################################################
 
 
+@unittest.skipIf(IMPORT_FAILED, "This depends on Word.")
 class Test(unittest.TestCase):
-    def tearDown(self):
-        if hasattr(self, "w1"):
-            self.w1.Quit()
-            del self.w1
-
-
-    def test(self):
+    def setUp(self):
         try:
             comtypes.client.GetActiveObject("Word.Application")
         except WindowsError:
@@ -27,10 +33,17 @@ class Test(unittest.TestCase):
         else:
             # seems word is running, we cannot test this.
             self.fail("MSWord is running, cannot test")
-
         # create a WORD instance
-        self.w1 = w1 = comtypes.client.CreateObject("Word.Application")
+        self.w1 = comtypes.client.CreateObject("Word.Application")
+
+    def tearDown(self):
+        if hasattr(self, "w1"):
+            self.w1.Quit()
+            del self.w1
+
+    def test(self):
         # connect to the running instance
+        w1 = self.w1
         w2 = comtypes.client.GetActiveObject("Word.Application")
 
         # check if they are referring to the same object
@@ -40,18 +53,16 @@ class Test(unittest.TestCase):
         w1.Quit()
         del self.w1
 
-        import time
         time.sleep(1)
 
-        try:
+        with self.assertRaises(comtypes.COMError) as arc:
             w2.Visible
-        except comtypes.COMError as err:
-            variables = err.hresult, err.text, err.details
-            self.assertEqual(variables, err[:])
-        else:
-            raise AssertionError("COMError not raised")
 
-        self.assertRaises(WindowsError, comtypes.client.GetActiveObject, "Word.Application")
+        err = arc.exception
+        variables = err.hresult, err.text, err.details
+        self.assertEqual(variables, err.args)
+        with self.assertRaises(WindowsError):
+            comtypes.client.GetActiveObject("Word.Application")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
explicit skipping tests